### PR TITLE
feat: update DPF submodule to commit ab3e4c3 on master branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "dpf"]
 	path = dpf
-	url = git://github.com/DISTRHO/DPF.git
+	url = https://github.com/DISTRHO/DPF.git


### PR DESCRIPTION
This fixes two things:

- makes build on non-x86 architectures possible because the DPF Makefile now has arch-specific compiler optimization flags.
- allows to remove the bypass-enable patch, because this is [now fixed in DPF](https://github.com/DISTRHO/DPF/commit/e889c58115b182364b095d60d0018c009163728f). 

Notes:

1. The DPF default branch is now `main`, but that is incompatible.
2. Due to new Github security policies, the submodule URL now has to use `https:` instead of `git:` 